### PR TITLE
Support close method

### DIFF
--- a/src/mrb_geoip.c
+++ b/src/mrb_geoip.c
@@ -37,8 +37,11 @@ static mrb_value mrb_geoip_close(mrb_state *mrb, mrb_value self)
 {
   mrb_geoip_data *data = (mrb_geoip_data *)DATA_PTR(self);
 
-  GeoIPRecord_delete(data->gir);
-  GeoIP_delete(data->gi);
+  if (data->gir != NULL)
+    GeoIPRecord_delete(data->gir);
+  if (data->gi != NULL)
+    GeoIP_delete(data->gi);
+
   mrb_free(mrb, data);
 
   return mrb_nil_value();

--- a/src/mrb_geoip.c
+++ b/src/mrb_geoip.c
@@ -33,6 +33,17 @@ static void mrb_geoip_free(mrb_state *mrb, void *p)
   GeoIP_delete(data->gi);
 }
 
+static mrb_value mrb_geoip_close(mrb_state *mrb, mrb_value self)
+{
+  mrb_geoip_data *data = (mrb_geoip_data *)DATA_PTR(self);
+
+  GeoIPRecord_delete(data->gir);
+  GeoIP_delete(data->gi);
+  mrb_free(mrb, data);
+
+  return mrb_nil_value();
+}
+
 static const struct mrb_data_type mrb_geoip_data_type = {
   "mrb_geoip_data", mrb_geoip_free,
 };
@@ -220,6 +231,7 @@ void mrb_mruby_geoip_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, geoip, "metro_code", mrb_geoip_metro_code, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "area_code", mrb_geoip_area_code, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "time_zone", mrb_geoip_time_zone, MRB_ARGS_NONE());
+    mrb_define_method(mrb, geoip, "close", mrb_geoip_close, MRB_ARGS_NONE());
     DONE;
 }
 

--- a/test/mrb_geoip.rb
+++ b/test/mrb_geoip.rb
@@ -81,3 +81,9 @@ assert("GeoIP#time_zone") do
   assert_equal("America/Los_Angeles", geoip.time_zone)
 end
 
+assert("GeoIP#close") do
+  geoip = GeoIP.new GeoIPdat
+
+  assert_equal(nil, geoip.close)
+end
+


### PR DESCRIPTION
fixed #1 
### memory usage of single geoip object

``` ruby
geoip = GeoIP.new "/usr/share/GeoIP/GeoIPCity.dat"
```
- 17608 KBytes

```
500      27035  0.1  0.0 131040 17608 pts/3    S+   10:56   0:00  |   \_ ./bin/mirb
```
### memory usage of the number of 100 geoip object

``` ruby
100.times { geoip = GeoIP.new "/usr/share/GeoIP/GeoIPCity.dat" }
```
- 1531984 KBytes .. ah!

```
500      26971  4.6  6.2 1645340 1531984 pts/3 S+   10:54   0:01  |   \_ ./bin/mirb
```
### memory usage after freeing the number of 100 geoip object

``` ruby
100.times { geoip = GeoIP.new "/usr/share/GeoIP/GeoIPCity.dat"; geoip.close }
```
- 17620 KBytes

```
500      27017  2.8  0.0 131064 17620 pts/3    S+   10:55   0:00  |   \_ ./bin/mirb
```
