### PR TITLE
Support geoip org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.csv
+*.dat
+*.mmdb
+*.gz
+*.zip
+geoip-api-c
+mruby
+.rake_tasks

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - sudo apt-get -qq install rake bison git gperf geoip-database libgeoip-dev
   - sudo wget -N http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
   - sudo gunzip GeoLiteCity.dat.gz
-  - sudo mv GeoLiteCity.dat /usr/share/GeoIP/GeoIPCity.dat
+  - sudo mv GeoLiteCity.dat /usr/local/share/GeoLiteCity.dat
   - sudo wget -P /usr/local/share/ https://raw.githubusercontent.com/maxmind/geoip-api-php/master/tests/data/GeoIPOrg.dat
 before_script:
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,5 @@ before_script:
   - cd ../
   - git clone https://github.com/mruby/mruby.git
   - cd mruby
-  - cp -fp ../mruby-geoip/.travis_build_config.rb build_config.rb
 script:
   - make all test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - sudo wget -N http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
   - sudo gunzip GeoLiteCity.dat.gz
   - sudo mv GeoLiteCity.dat /usr/share/GeoIP/GeoIPCity.dat
+  - sudo wget -P /usr/local/share/ https://raw.githubusercontent.com/maxmind/geoip-api-php/master/tests/data/GeoIPOrg.dat
 before_script:
   - cd ../
   - git clone https://github.com/mruby/mruby.git

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -2,4 +2,5 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
   conf.gem '../mruby-geoip'
+  conf.enable_test
 end

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:latest
+RUN yum -y groupinstall "Development Tools"
+RUN yum -y install ruby \
+    ruby-gems \
+    yum \
+    wget \
+    git
+
+RUN gem install rake
+RUN git clone https://github.com/maxmind/geoip-api-c
+RUN cd geoip-api-c \
+    && ./bootstrap \
+    && ./configure -prefix=/usr \
+    && make \
+    && make install
+RUN wget -P /usr/local/share/ https://raw.githubusercontent.com/maxmind/geoip-api-php/master/tests/data/GeoIPOrg.dat
+RUN wget -P /usr/local/share/ http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
+    && gunzip /usr/local/share/GeoLiteCity.dat.gz
+ENV LD_LIBRARY_PATH /usr/lib
+CMD rake test

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ RUN wget -P /usr/local/share/ https://raw.githubusercontent.com/maxmind/geoip-ap
 RUN wget -P /usr/local/share/ http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
     && gunzip /usr/local/share/GeoLiteCity.dat.gz
 ENV LD_LIBRARY_PATH /usr/lib
-CMD rake test
+ADD . /tmp/mruby-geoip
+WORKDIR /tmp/mruby-geoip
+CMD cp .travis_build_config.rb build_config.rb && rake test

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN wget -P /usr/local/share/ http://geolite.maxmind.com/download/geoip/database
 ENV LD_LIBRARY_PATH /usr/lib
 ADD . /tmp/mruby-geoip
 WORKDIR /tmp/mruby-geoip
-CMD cp .travis_build_config.rb build_config.rb && rake test
+CMD rake test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mruby-geoip   [![Build Status](https://travis-ci.org/matsumoto-r/mruby-geoip.png?branch=master)](https://travis-ci.org/matsumoto-r/mruby-geoip)
+# mruby-geoip   [![Build Status](https://travis-ci.org/matsumotory/mruby-geoip.png?branch=master)](https://travis-ci.org/matsumotory/mruby-geoip)
 GeoIPCity class using [GeoIPCity.dat](http://dev.maxmind.com/geoip/legacy/install/city/) for mruby
 ## install by mrbgems
 - add conf.gem line to `build_config.rb`

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
+
+file :mruby do
+  sh "git clone git://github.com/mruby/mruby.git"
+end
+
+desc "compile binary"
+task :compile => :mruby do
+  sh "cd mruby && MRUBY_CONFIG=#{MRUBY_CONFIG} rake all"
+end
+
+desc "test"
+task :test => :mruby do
+  sh "cd mruby && MRUBY_CONFIG=#{MRUBY_CONFIG} rake all test"
+end
+
+desc "cleanup"
+task :clean do
+  sh "cd mruby && rake deep_clean"
+end
+
+desc "run docker"
+task :docker do
+  sh "docker build -t mruby:geoip ."
+  sh "docker run -v `pwd`:/tmp/mruby-geoip -w /tmp/mruby-geoip -it mruby:geoip"
+end
+
+task :default => :test

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,6 +1,0 @@
-MRuby::Build.new do |conf|
-  toolchain :gcc
-  conf.gembox 'default'
-  conf.gem File.expand_path(File.dirname(__FILE__))
-  conf.enable_test
-end

--- a/build_config.rb
+++ b/build_config.rb
@@ -2,6 +2,5 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
   conf.gem File.expand_path(File.dirname(__FILE__))
-  conf.gem :github => 'iij/mruby-io'
   conf.enable_test
 end

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,6 +1,6 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
-  conf.gem '../mruby-geoip'
+  conf.gem File.expand_path(File.dirname(__FILE__))
   conf.enable_test
 end

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,0 +1,7 @@
+MRuby::Build.new do |conf|
+  toolchain :gcc
+  conf.gembox 'default'
+  conf.gem File.expand_path(File.dirname(__FILE__))
+  conf.gem :github => 'iij/mruby-io'
+  conf.enable_test
+end

--- a/src/mrb_geoip.c
+++ b/src/mrb_geoip.c
@@ -58,6 +58,7 @@ static mrb_value mrb_geoip_init(mrb_state *mrb, mrb_value self)
   mrb_geoip_data *data;
   char *city_db;
   char *isp_db;
+  int argc;
 
   data = (mrb_geoip_data *)DATA_PTR(self);
   if (data) {
@@ -66,7 +67,7 @@ static mrb_value mrb_geoip_init(mrb_state *mrb, mrb_value self)
   DATA_TYPE(self) = &mrb_geoip_data_type;
   DATA_PTR(self) = NULL;
 
-  int argc = mrb_get_args(mrb, "z|z", &city_db, &isp_db);
+  mrb_get_args(mrb, "z|z", &city_db, &isp_db);
   data = (mrb_geoip_data *)mrb_malloc(mrb, sizeof(mrb_geoip_data));
   data->city_db = city_db;
   data->host = NULL;

--- a/src/mrb_geoip.c
+++ b/src/mrb_geoip.c
@@ -16,9 +16,11 @@
 
 typedef struct {
   GeoIP *gi;
+  GeoIP *isp_gi;
   GeoIPRecord *gir;
-  char *db;
+  char *city_db;
   char *host;
+  char *(*org_function)(GeoIP *gi, const char *host);
 } mrb_geoip_data;
 
 static const char *MK_STR(const char *str){
@@ -54,7 +56,8 @@ static const struct mrb_data_type mrb_geoip_data_type = {
 static mrb_value mrb_geoip_init(mrb_state *mrb, mrb_value self)
 {
   mrb_geoip_data *data;
-  char *db;
+  char *city_db;
+  char *isp_db;
 
   data = (mrb_geoip_data *)DATA_PTR(self);
   if (data) {
@@ -63,14 +66,23 @@ static mrb_value mrb_geoip_init(mrb_state *mrb, mrb_value self)
   DATA_TYPE(self) = &mrb_geoip_data_type;
   DATA_PTR(self) = NULL;
 
-  mrb_get_args(mrb, "z", &db);
+  int argc = mrb_get_args(mrb, "z|z", &city_db, &isp_db);
   data = (mrb_geoip_data *)mrb_malloc(mrb, sizeof(mrb_geoip_data));
-  data->db = db;
+  data->city_db = city_db;
   data->host = NULL;
-  data->gi = GeoIP_open(db, GEOIP_INDEX_CACHE);
+
+  data->gi = GeoIP_open(city_db, GEOIP_INDEX_CACHE);
   if (data->gi == NULL) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "GeoIP database open fail");
   }
+
+  if (argc == 2) {
+    data->isp_gi = GeoIP_open(isp_db, GEOIP_INDEX_CACHE);
+    if (data->isp_gi == NULL) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, "GeoIP ISP database open fail");
+    }
+  }
+
   data->gir = NULL;
   DATA_PTR(self) = data;
 
@@ -93,6 +105,7 @@ static mrb_value mrb_geoip_record_by_name(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "not found GeoIP record for hostanme");
   }
 
+  data->org_function = GeoIP_org_by_name;
   return self;
 }
 
@@ -112,6 +125,7 @@ static mrb_value mrb_geoip_record_by_addr(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "not found GeoIP record for IP address");
   }
 
+  data->org_function = GeoIP_org_by_addr;
   return self;
 }
 
@@ -164,6 +178,14 @@ static mrb_value mrb_geoip_postal_code(mrb_state *mrb, mrb_value self)
        " call record_by_name or record_by_addr method");
   }
   return mrb_str_new_cstr(mrb, MK_STR(data->gir->postal_code));
+}
+
+static mrb_value mrb_geoip_org(mrb_state *mrb, mrb_value self)
+{
+  mrb_geoip_data *data = DATA_PTR(self);
+  return mrb_str_new_cstr(mrb, MK_STR(data->org_function(
+          data->isp_gi, data->host)));
+
 }
 
 static mrb_value mrb_geoip_latitude(mrb_state *mrb, mrb_value self)
@@ -221,7 +243,7 @@ void mrb_mruby_geoip_gem_init(mrb_state *mrb)
 {
     struct RClass *geoip;
     geoip = mrb_define_class(mrb, "GeoIP", mrb->object_class);
-    mrb_define_method(mrb, geoip, "initialize", mrb_geoip_init, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, geoip, "initialize", mrb_geoip_init, MRB_ARGS_ARG(1, 1));
     mrb_define_method(mrb, geoip, "record_by_name", mrb_geoip_record_by_name, MRB_ARGS_REQ(1));
     mrb_define_method(mrb, geoip, "record_by_addr", mrb_geoip_record_by_addr, MRB_ARGS_REQ(1));
     mrb_define_method(mrb, geoip, "country_code", mrb_geoip_country_code, MRB_ARGS_NONE());
@@ -229,6 +251,7 @@ void mrb_mruby_geoip_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, geoip, "region_name", mrb_geoip_region_name, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "city", mrb_geoip_city, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "postal_code", mrb_geoip_postal_code, MRB_ARGS_NONE());
+    mrb_define_method(mrb, geoip, "org", mrb_geoip_org, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "latitude", mrb_geoip_latitude, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "longitude", mrb_geoip_longitude, MRB_ARGS_NONE());
     mrb_define_method(mrb, geoip, "metro_code", mrb_geoip_metro_code, MRB_ARGS_NONE());

--- a/src/mrb_geoip.c
+++ b/src/mrb_geoip.c
@@ -67,7 +67,7 @@ static mrb_value mrb_geoip_init(mrb_state *mrb, mrb_value self)
   DATA_TYPE(self) = &mrb_geoip_data_type;
   DATA_PTR(self) = NULL;
 
-  mrb_get_args(mrb, "z|z", &city_db, &isp_db);
+  argc = mrb_get_args(mrb, "z|z", &city_db, &isp_db);
   data = (mrb_geoip_data *)mrb_malloc(mrb, sizeof(mrb_geoip_data));
   data->city_db = city_db;
   data->host = NULL;

--- a/test/mrb_geoip.rb
+++ b/test/mrb_geoip.rb
@@ -3,7 +3,7 @@
 ##
 
 GeoIPdat = '/usr/local/share/GeoLiteCity.dat'
-GeoIPhost = 'www.google.com'
+GeoIPhost = '216.58.200.196'
 
 # from: https://github.com/maxmind/geoip-api-php/blob/master/tests/data/GeoIPOrg.dat
 GeoIPIspdat = '/usr/local/share/GeoIPOrg.dat'
@@ -16,35 +16,35 @@ end
 
 assert("GeoIP#country_code") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal("US", geoip.country_code)
 end
 
 assert("GeoIP#region") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal("CA", geoip.region)
 end
 
 assert("GeoIP#region_name") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal("California", geoip.region_name)
 end
 
 assert("GeoIP#city") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal("Mountain View", geoip.city)
 end
 
 assert("GeoIP#postal_code") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal("94043", geoip.postal_code)
 end
@@ -58,35 +58,35 @@ end
 
 assert("GeoIP#latitude") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal(37.4192, geoip.latitude.round(4))
 end
 
 assert("GeoIP#longitude") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal(-122.0574, geoip.longitude.round(4))
 end
 
 assert("GeoIP#metro_code") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal(807, geoip.metro_code)
 end
 
 assert("GeoIP#area_code") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal(650, geoip.area_code)
 end
 
 assert("GeoIP#time_zone") do
   geoip = GeoIP.new GeoIPdat
-  geoip.record_by_name GeoIPhost
+  geoip.record_by_addr GeoIPhost
 
   assert_equal("America/Los_Angeles", geoip.time_zone)
 end

--- a/test/mrb_geoip.rb
+++ b/test/mrb_geoip.rb
@@ -2,8 +2,11 @@
 ## GeoIP Test
 ##
 
-GeoIPdat = "/usr/share/GeoIP/GeoIPCity.dat"
-GeoIPhost = "www.google.com"
+GeoIPdat = '/usr/local/share/GeoLiteCity.dat'
+GeoIPhost = 'www.google.com'
+
+# from: https://github.com/maxmind/geoip-api-php/blob/master/tests/data/GeoIPOrg.dat
+GeoIPIspdat = '/usr/local/share/GeoIPOrg.dat'
 
 assert("GeoIP#new") do
   geoip = GeoIP.new GeoIPdat
@@ -46,6 +49,13 @@ assert("GeoIP#postal_code") do
   assert_equal("94043", geoip.postal_code)
 end
 
+assert("GeoIP#org") do
+  geoip = GeoIP.new(GeoIPdat, GeoIPIspdat)
+  geoip.record_by_addr '64.17.254.216'
+
+  assert_equal('Karlin Peebles LLP', geoip.org)
+end
+
 assert("GeoIP#latitude") do
   geoip = GeoIP.new GeoIPdat
   geoip.record_by_name GeoIPhost
@@ -86,4 +96,3 @@ assert("GeoIP#close") do
 
   assert_equal(nil, geoip.close)
 end
-


### PR DESCRIPTION
refs: https://github.com/matsumotory/mruby-geoip/issues/3

このPRを取り込むと、geoip_orgパラメーターの値が取得可能になります。取得元のDBが複数必要となるため、GeoIPクラスのコンストラクタ時に複数のDBファイルを引数に与えて使用する実装にしています。また合わせてテスト実行環境の整備を行っております。